### PR TITLE
`oras push` to docker dest breaks docker manifest

### DIFF
--- a/.github/workflows/container_build_push.yml
+++ b/.github/workflows/container_build_push.yml
@@ -76,12 +76,10 @@ jobs:
           IFS= read -r first_tag <<EOF
           $tags
           EOF
-          echo "The first tag is: $first_tag"
-          echo "CSV-tags are: $csv_tags"
+          push_tags="$(printf $csv_tags | sed -e "s/ldpred2/ldpred2_sif/g")"
           echo ${{ secrets.GITHUB_TOKEN }} | oras login --username ${{ github.repository_owner }} --password-stdin ghcr.io
           docker pull kaczmarj/apptainer:latest
-          echo "processing tag: $first_tag"
           docker run --rm --privileged -v $(pwd):/work kaczmarj/apptainer build ldpred2.sif docker://"$first_tag"
-          oras push "$csv_tags" --artifact-type application/vnd.acme.rocket.config ldpred2.sif
+          oras push "$push_tags" --artifact-type application/vnd.acme.rocket.config ldpred2.sif
           rm ldpred2.sif
         shell: sh

--- a/docker/dockerfiles/ldpred2/Dockerfile
+++ b/docker/dockerfiles/ldpred2/Dockerfile
@@ -2,6 +2,10 @@
 FROM rocker/r-ver:4.3.3
 RUN /rocker_scripts/setup_R.sh https://packagemanager.posit.co/cran/__linux__/jammy/2024-03-01
 
+LABEL org.opencontainers.image.source=https://github.com/comorment/ldpred2_standalone
+LABEL org.opencontainers.image.description="R, Rstudio, LDpred2 dependencies, PLINK, PRSice2, Python"
+LABEL org.opencontainers.image.licenses=GPL-3.0
+
 ENV TZ=Europe
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/scripts/LDpred2/README.md
+++ b/scripts/LDpred2/README.md
@@ -40,7 +40,7 @@ $ singularity pull docker://ghcr.io/comorment/ldpred2:latest
 or using the [ORAS CLI](https://oras.land)
 
 ```
-$ oras pull ghcr.io/comorment/ldpred2:latest
+$ oras pull ghcr.io/comorment/ldpred2_sif:latest
 ```
 
 Either of the above will put the container in the current directory as `ldpred2.sif`.


### PR DESCRIPTION

<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #22

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Fix issue where "oras push" operation replaces docker image manifest

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/comorment/ldpred2_standalone/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/comorment/ldpred2_standalone/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
